### PR TITLE
refactor!: throw errors

### DIFF
--- a/github-notifications/index.js
+++ b/github-notifications/index.js
@@ -1,6 +1,3 @@
-const {
-  constants: { ERRORS },
-} = require('@notify-watcher/core');
 const config = require('./config');
 
 const GITHUB_AUTH_URL = 'https://api.github.com/user';

--- a/gtd/index.js
+++ b/gtd/index.js
@@ -3,19 +3,7 @@ const { fetchPlans, planEquals } = require('./gtd-plans');
 
 async function watch({ snapshot: previousSnapshot, libs }) {
   const { lodash, axios, cheerio } = libs;
-  let snapshot;
-  try {
-    snapshot = await fetchPlans(axios, cheerio, lodash);
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('gtd error:', error);
-    // TODO: Notify server of the error
-    return {
-      snapshot,
-      notifications: [],
-      error,
-    };
-  }
+  const snapshot = await fetchPlans(axios, cheerio, lodash);
   const newPlans = lodash.differenceWith(
     snapshot,
     previousSnapshot,

--- a/gtd/index.js
+++ b/gtd/index.js
@@ -3,7 +3,14 @@ const { fetchPlans, planEquals } = require('./gtd-plans');
 
 async function watch({ snapshot: previousSnapshot, libs }) {
   const { lodash, axios, cheerio } = libs;
-  const snapshot = await fetchPlans(axios, cheerio, lodash);
+  let snapshot;
+  try {
+    snapshot = await fetchPlans(axios, cheerio, lodash);
+  } catch (error) {
+    if (error.response) throw error.response;
+    throw error;
+  }
+
   const newPlans = lodash.differenceWith(
     snapshot,
     previousSnapshot,

--- a/index.js
+++ b/index.js
@@ -1,12 +1,16 @@
 /* eslint-disable no-console */
 const util = require('util');
 const { Executor } = require('@notify-watcher/executor');
-const githubNotificationsWatcher = require('./github-notifications');
-const gtdPlansWatcher = require('./gtd');
-const uniredTagWatcher = require('./unired-tag');
-const vtrPlansWatcher = require('./vtr');
+const githubNotificationsWatcher = require('./github-notifications'); // eslint-disable-line no-unused-vars
+const gtdPlansWatcher = require('./gtd'); // eslint-disable-line no-unused-vars
+const uniredTagWatcher = require('./unired-tag'); // eslint-disable-line no-unused-vars
+const vtrPlansWatcher = require('./vtr'); // eslint-disable-line no-unused-vars
 
 const executor = new Executor();
+
+const LOCAL_ENV = {
+  logError: false,
+};
 
 async function checkAuth(watcher, auth) {
   const authOk = await executor.run(watcher.checkAuth, { auth });
@@ -18,7 +22,9 @@ async function runWatcher(watcher, snapshot, auth = {}) {
   try {
     data = await executor.run(watcher.watch, { snapshot, auth });
   } catch (error) {
-    console.error(`# ${watcher.config.name} error\n${error}`);
+    console.error(`# ${watcher.config.name} error ${error.status}`);
+    if (LOCAL_ENV.logError) console.error(error);
+    return undefined;
   }
 
   const { snapshot: newSnapshot, notifications } = data;
@@ -34,7 +40,7 @@ async function runWatcher(watcher, snapshot, auth = {}) {
 
 async function runWatcherTwice(watcher, auth = {}) {
   const data = await runWatcher(watcher, {}, auth);
-  await runWatcher(watcher, data.snapshot, auth);
+  if (data) await runWatcher(watcher, data.snapshot, auth);
 }
 
 // eslint-disable-next-line no-unused-vars
@@ -46,14 +52,14 @@ async function checkAuthGithubNotifications() {
 
 // eslint-disable-next-line no-unused-vars
 async function watchGithubNotifications() {
-  await runWatcherTwice('github-notifications', githubNotificationsWatcher, {
+  await runWatcherTwice(githubNotificationsWatcher, {
     token: process.env.GITHUB_NOTIFICATIONS_TOKEN,
   });
 }
 
 // eslint-disable-next-line no-unused-vars
 async function watchUniredTag() {
-  await runWatcherTwice('unired-tag', uniredTagWatcher, {
+  await runWatcherTwice(uniredTagWatcher, {
     rut: process.env.rut,
   });
 }
@@ -63,8 +69,8 @@ Promise.all([
     Add other watchWatcher here to develop
     Comment to avoid calling
   */
-  checkAuthGithubNotifications(),
-  watchGithubNotifications(),
-  runWatcherTwice(vtrPlansWatcher),
-  runWatcherTwice(gtdPlansWatcher),
+  // checkAuthGithubNotifications(),
+  // watchGithubNotifications(),
+  // runWatcherTwice(vtrPlansWatcher),
+  // runWatcherTwice(gtdPlansWatcher),
 ]);

--- a/unired-tag/index.js
+++ b/unired-tag/index.js
@@ -1,6 +1,3 @@
-const {
-  constants: { ERRORS },
-} = require('@notify-watcher/core');
 const config = require('./config');
 
 const UNIRED_URL = 'https://www.unired.cl';
@@ -20,56 +17,47 @@ async function watch({ auth: { rut }, libs: { puppeteer }, snapshot }) {
     },
   });
 
-  try {
-    const page = await browser.newPage();
-    await page.goto(UNIRED_URL);
+  const page = await browser.newPage();
+  await page.goto(UNIRED_URL);
 
-    // this popup hides the buttons, but maybe they'll remove it
-    // and this watcher shouldn't fail because it doesn't find it
-    await page.click('#irAUnired').catch(() => {});
+  // this popup hides the buttons, but maybe they'll remove it
+  // and this watcher shouldn't fail because it doesn't find it
+  await page.click('#irAUnired').catch(() => {});
 
-    await waitAndClick(page, '#IdEmpresaRubro_autocomplete');
-    await page.keyboard.type('Tag Total');
-    await waitAndClick(page, '.ui-corner-all');
-    await waitAndClick(page, '#express_continuar');
+  await waitAndClick(page, '#IdEmpresaRubro_autocomplete');
+  await page.keyboard.type('Tag Total');
+  await waitAndClick(page, '.ui-corner-all');
+  await waitAndClick(page, '#express_continuar');
 
-    await waitAndClick(page, '#ValorIdentificador');
-    await page.keyboard.type(rut);
-    await waitAndClick(page, '#express_agregar_cuenta_aceptar');
+  await waitAndClick(page, '#ValorIdentificador');
+  await page.keyboard.type(rut);
+  await waitAndClick(page, '#express_agregar_cuenta_aceptar');
 
-    await Promise.all([
-      page.waitForNavigation({
-        waitUntil: 'networkidle0',
-      }),
-      waitAndClick(page, '#express_pagar'),
-    ]);
+  await Promise.all([
+    page.waitForNavigation({
+      waitUntil: 'networkidle0',
+    }),
+    waitAndClick(page, '#express_pagar'),
+  ]);
 
-    const span = await page.$('#TotalPagar');
-    const text = await page.evaluate(element => element.textContent, span);
-    const ballot = text.replace('Total a pagar: $', '').trim();
+  const span = await page.$('#TotalPagar');
+  const text = await page.evaluate(element => element.textContent, span);
+  const ballot = text.replace('Total a pagar: $', '').trim();
 
-    const notifications = [];
-    if (ballot !== snapshot.ballot) {
-      notifications.push({
-        type: config.notificationTypes.updatedBallot.key,
-        message: `Your tag ballot is ${ballot}`,
-      });
-    }
-
-    return {
-      snapshot: { ballot },
-      notifications,
-    };
-  } catch (error) {
-    error.key = ERRORS.other;
-    return {
-      snapshot,
-      notifications: [],
-      error,
-    };
-  } finally {
-    await browser.close();
+  const notifications = [];
+  if (ballot !== snapshot.ballot) {
+    notifications.push({
+      type: config.notificationTypes.updatedBallot.key,
+      message: `Your tag ballot is ${ballot}`,
+    });
   }
+
+  browser.close();
+
+  return {
+    snapshot: { ballot },
+    notifications,
+  };
 }
 
 module.exports = {

--- a/vtr/index.js
+++ b/vtr/index.js
@@ -3,7 +3,14 @@ const { fetchPlans, planEquals } = require('./vtr-plans');
 
 async function watch({ snapshot: previousSnapshot, libs }) {
   const { lodash, axios, cheerio } = libs;
-  const snapshot = await fetchPlans(axios, cheerio);
+  let snapshot;
+  try {
+    snapshot = await fetchPlans(axios, cheerio);
+  } catch (error) {
+    if (error.response) throw error.response;
+    throw error;
+  }
+
   const newPlans = lodash.differenceWith(
     snapshot,
     previousSnapshot,

--- a/vtr/index.js
+++ b/vtr/index.js
@@ -3,19 +3,7 @@ const { fetchPlans, planEquals } = require('./vtr-plans');
 
 async function watch({ snapshot: previousSnapshot, libs }) {
   const { lodash, axios, cheerio } = libs;
-  let snapshot;
-  try {
-    snapshot = await fetchPlans(axios, cheerio);
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('vtr error:', error);
-    // TODO: Notify server of the error
-    return {
-      snapshot,
-      notifications: [],
-      error,
-    };
-  }
+  const snapshot = await fetchPlans(axios, cheerio);
   const newPlans = lodash.differenceWith(
     snapshot,
     previousSnapshot,


### PR DESCRIPTION
- Remove `core` `ERRORS`
- If watcher has `error.response`, throw it
  - If not, just throw the `error`
- Refactor index.js for easier running watchers in dev

Related to https://github.com/notify-watcher/core/pull/23
Closes #42 